### PR TITLE
Add real SaneHosts UI action executor

### DIFF
--- a/scripts/customer_ui_action_executor.rb
+++ b/scripts/customer_ui_action_executor.rb
@@ -1,0 +1,476 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'optparse'
+require 'socket'
+require 'time'
+require 'yaml'
+
+class SaneHostsUIActionExecutor
+  ROOT = File.expand_path('..', __dir__)
+  MANIFEST = File.join(ROOT, 'Tests', 'CustomerUIActions.yml')
+  AX_SOURCE = File.join(__dir__, 'customer_ui_ax_driver.swift')
+  SCREENSHOT_WRAPPER = File.expand_path('../../infra/SaneProcess/scripts/mini/capture-mini-screenshot.sh', ROOT)
+  APP_BUNDLE_ID = 'com.mrsane.SaneHosts'
+  FIXTURE_PROFILE = 'UI Proof Profile'
+  FIXTURE_HOST = 'proof.invalid'
+
+  SAFE_BOUNDARIES = {
+    'menu-bar-profile-actions' => [
+      'Stopped before administrator authorization, /etc/hosts mutation, update checks, support sends, and Quit.'
+    ],
+    'dock-and-app-menu-commands' => [
+      'Stopped before deactivation, update checks, support sends, and Quit.'
+    ],
+    'profile-lifecycle-actions' => [
+      'Export reached the save panel and was canceled; profile deletion reached confirmation and was canceled.'
+    ],
+    'preset-template-import-actions' => [
+      'Custom import used an invalid local fixture URL and stopped before external network completion.'
+    ],
+    'activation-deactivation-hosts-write' => [
+      'Opened the activation route but stopped before administrator authorization or real /etc/hosts mutation.'
+    ],
+    'bulk-entry-actions' => [
+      'Bulk delete was not performed; enable and disable used only the isolated UI-proof profile.'
+    ],
+    'settings-license-about-update-support' => [
+      'Stopped before live update checks, checkout, license activation, or support sends.'
+    ],
+    'persistence-security-and-release-surfaces' => [
+      'Verified isolated profile persistence and safe customer surfaces without privileged writes.'
+    ]
+  }.freeze
+
+  attr_reader :plans
+
+  def initialize(argv = [])
+    @execute = false
+    OptionParser.new do |parser|
+      parser.banner = 'Usage: customer_ui_action_executor.rb [--plan | --execute]'
+      parser.on('--plan', 'Print the AX/control/readback/artifact plan without touching the GUI') {}
+      parser.on('--execute', 'Run the real Mini action lane') { @execute = true }
+    end.parse!(argv)
+    @manifest = YAML.safe_load(File.read(MANIFEST), aliases: false)
+    @actions = Array(@manifest.fetch('actions')).select { |action| action['release_required'] != false }
+    @plans = build_plans
+    validate_plan!
+  end
+
+  def run
+    return puts(JSON.pretty_generate(plan_report)) unless @execute
+
+    require_mini!
+    require_clean_checkout!
+    refuse_competing_gui!
+    prepare_paths!
+    begin
+      prepare_isolated_fixture!
+      compile_ax_driver!
+      start_live_log!
+      launch_app!
+      load_contract_identity!
+      @actions.each { |action| execute_action!(action) }
+      write_execution_evidence!
+      ingest_evidence!
+      puts @execution_path
+    rescue StandardError => e
+      write_failure(e)
+      raise
+    ensure
+      stop_live_log!
+      restore_gui_environment!
+    end
+  end
+
+  def plan_report
+    {
+      app: 'SaneHosts',
+      execution_mode: @execute ? 'executed' : 'not_executed',
+      action_count: @actions.length,
+      actions: @actions.map do |action|
+        plan = @plans.fetch(action.fetch('id'))
+        {
+          id: action.fetch('id'),
+          controls: plan.map { |step| step.fetch(:labels) },
+          ax_actions: plan.map { |step| step.fetch(:action) },
+          readbacks: plan.map { |step| step.fetch(:expected) },
+          screenshot: "outputs/customer-ui/sweep-<timestamp>/visual/#{action.fetch('id')}.png",
+          click_receipt: "outputs/customer-ui/sweep-<timestamp>/#{action.fetch('id')}-click.json",
+          state_receipt: "outputs/customer-ui/sweep-<timestamp>/#{action.fetch('id')}-state.json",
+          safe_boundaries: SAFE_BOUNDARIES.fetch(action.fetch('id'), [])
+        }
+      end
+    }
+  end
+
+  private
+
+  def step(labels, action:, expected:, app_name: 'SaneHosts', bundle_id: APP_BUNDLE_ID, roles: nil, value: nil)
+    {
+      labels: Array(labels),
+      action: action,
+      expected: Array(expected).map { |group| Array(group) },
+      app_name: app_name,
+      bundle_id: bundle_id,
+      roles: Array(roles).compact,
+      value: value
+    }
+  end
+
+  def build_plans
+    {
+      'onboarding-and-tutorial-entry' => [
+        step(%w[Continue Get\ Started Next] + ['Continue Trial', 'Start Using SaneHosts'], action: 'press',
+             expected: [['QUICK ACTIONS', 'Next', 'Continue Trial', 'Start Using SaneHosts']]),
+        step('Help', action: 'press', roles: 'AXMenuBarItem', expected: ['Show Tutorial']),
+        step('Show Tutorial', action: 'press', expected: [['Next step', 'Skip tutorial']]),
+        step('Next step', action: 'press', expected: ['Finish tutorial']),
+        step('Finish tutorial', action: 'press', expected: ['QUICK ACTIONS'])
+      ],
+      'menu-bar-profile-actions' => [
+        step('SaneHosts', action: 'show_menu', roles: 'AXMenuBarItem',
+             expected: [['Open SaneHosts'], ['Quit SaneHosts']]),
+        step('Open SaneHosts', action: 'press', expected: ['QUICK ACTIONS'])
+      ],
+      'dock-and-app-menu-commands' => [
+        step('SaneHosts', action: 'show_menu', app_name: 'Dock', bundle_id: 'com.apple.dock',
+             roles: 'AXDockItem', expected: [['Open SaneHosts'], ['Settings']]),
+        step('File', action: 'press', roles: 'AXMenuBarItem',
+             expected: [['New Profile'], ['Import Blocklist']]),
+        step('New Profile', action: 'press', expected: [['New Profile'], ['Create']]),
+        step('Cancel', action: 'press', expected: ['QUICK ACTIONS'])
+      ],
+      'quick-actions-and-paid-access-gates' => [
+        step('Open Essentials', action: 'press', expected: ['Essentials']),
+        step('Import Blocklist', action: 'press', expected: ['Import Blocklists']),
+        step('Cancel', action: 'press', expected: ['ADVANCED TOOLS']),
+        step('Merge Profiles', action: 'press',
+             expected: [['Create or import a second profile', 'Merge Profiles']])
+      ],
+      'profile-lifecycle-actions' => [
+        step('New Empty Profile', action: 'press', expected: [['New Profile'], ['My Profile']]),
+        step('My Profile', action: 'set_value', value: FIXTURE_PROFILE, expected: [FIXTURE_PROFILE]),
+        step('Create', action: 'press', expected: [FIXTURE_PROFILE]),
+        step(FIXTURE_PROFILE, action: 'show_menu', expected: [['Duplicate'], ['Export'], ['Delete']]),
+        step('Duplicate', action: 'press', expected: ["#{FIXTURE_PROFILE} 1"]),
+        step('Merge Profiles', action: 'press', expected: [['Merge Profiles'], ["Select #{FIXTURE_PROFILE}"]]),
+        step("Select #{FIXTURE_PROFILE}", action: 'press', expected: ["Deselect #{FIXTURE_PROFILE}"]),
+        step('Merge', action: 'press', expected: [['Profiles', 'Merged']]),
+        step(FIXTURE_PROFILE, action: 'show_menu', expected: ['Export']),
+        step('Export', action: 'press', expected: [['Save'], ['Cancel']]),
+        step('Cancel', action: 'press', expected: [FIXTURE_PROFILE]),
+        step(FIXTURE_PROFILE, action: 'show_menu', expected: ['Delete']),
+        step('Delete', action: 'press', expected: [['This action cannot be undone', 'Delete']]),
+        step('Cancel', action: 'press', expected: [FIXTURE_PROFILE])
+      ],
+      'preset-template-import-actions' => [
+        step('Family Safe protection level', action: 'press', expected: ['Add Family Safe']),
+        step('From Template', action: 'press', expected: ['Create from Template']),
+        step('Cancel template selection', action: 'press', expected: ['ADVANCED TOOLS']),
+        step('Import Blocklist', action: 'press', expected: ['Import Blocklists']),
+        step('Show custom URL input', action: 'press', expected: ['Custom URL']),
+        step('https://example.com/hosts', action: 'set_value', value: 'http://proof.invalid/hosts',
+             expected: ['Only HTTPS URLs are supported']),
+        step('Cancel', action: 'press', expected: ['ADVANCED TOOLS'])
+      ],
+      'activation-deactivation-hosts-write' => [
+        step('Essentials', action: 'show_menu', expected: [['Activate'], ['Export']])
+      ],
+      'entry-crud-search-toggle-actions' => [
+        step(FIXTURE_PROFILE, action: 'press', expected: ['Add new host entry']),
+        step('Add new host entry', action: 'press', expected: [['Add Entry'], ['example.local']]),
+        step('example.local', action: 'set_value', value: FIXTURE_HOST, expected: [FIXTURE_HOST]),
+        step('Add Entry', action: 'press', expected: [FIXTURE_HOST]),
+        step(FIXTURE_HOST, action: 'show_menu', expected: [['Edit'], ['Duplicate'], ['Delete']]),
+        step('Duplicate', action: 'press', expected: [FIXTURE_HOST]),
+        step("Disable #{FIXTURE_HOST}", action: 'press', expected: ["Enable #{FIXTURE_HOST}"]),
+        step('Filter entries', action: 'set_value', value: FIXTURE_HOST, expected: [FIXTURE_HOST])
+      ],
+      'bulk-entry-actions' => [
+        step('Enter selection mode', action: 'press', expected: [['Select all entries'], ['Done selecting']]),
+        step("Select #{FIXTURE_HOST}", action: 'press', expected: ["Deselect #{FIXTURE_HOST}"]),
+        step('Disable selected entries', action: 'press', expected: ['Enable selected entries']),
+        step('Enable selected entries', action: 'press', expected: ['Disable selected entries']),
+        step('Done selecting', action: 'press', expected: [FIXTURE_HOST])
+      ],
+      'settings-license-about-update-support' => [
+        step('SaneHosts', action: 'press', roles: 'AXMenuBarItem', expected: ['Settings']),
+        step('Settings', action: 'press', expected: [['General'], ['License'], ['About']]),
+        step('License', action: 'press', expected: [['License Key', 'Buy Full Access']]),
+        step('About', action: 'press', expected: [['Report a Bug'], ['Sparkle']])
+      ],
+      'persistence-security-and-release-surfaces' => [
+        step('General', action: 'press', expected: [['Software Updates'], ['Startup']]),
+        step('Open Essentials', action: 'press', expected: [['Profile status', 'Essentials']])
+      ]
+    }
+  end
+
+  def validate_plan!
+    ids = @actions.map { |action| action.fetch('id') }
+    difference = (@plans.keys - ids) + (ids - @plans.keys)
+    raise "Plan ids differ from manifest: #{difference.join(', ')}" unless difference.empty?
+
+    @plans.each do |id, action_steps|
+      raise "#{id}: no AX steps" if action_steps.empty?
+      raise "#{id}: no actual AX mutation" unless action_steps.any? { |item| item[:action] != 'read' }
+      action_steps.each do |item|
+        raise "#{id}: blank control selector" if item[:labels].empty?
+        raise "#{id}: missing bound readback" if item[:expected].empty?
+      end
+    end
+  end
+
+  def require_mini!
+    return if Socket.gethostname.downcase.include?('mini')
+
+    raise 'Real SaneHosts action execution must run on the Mini'
+  end
+
+  def require_clean_checkout!
+    out, status = Open3.capture2e('git', '-C', ROOT, 'status', '--porcelain')
+    raise "SaneHosts checkout is not clean:\n#{out}" unless status.success? && out.strip.empty?
+  end
+
+  def refuse_competing_gui!
+    raise 'SaneClick still owns the Mini GUI; stop it before running SaneHosts' if system('pgrep', '-x', 'SaneClick', out: File::NULL)
+    raise 'SaneHosts is already running; live log must attach before launch' if system('pgrep', '-x', 'SaneHosts', out: File::NULL)
+  end
+
+  def prepare_paths!
+    @timestamp = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
+    @run_rel = "outputs/customer-ui/sweep-#{@timestamp}"
+    @run_dir = File.join(ROOT, @run_rel)
+    @visual_dir = File.join(@run_dir, 'visual')
+    @live_log_rel = "outputs/live-logs/customer_ui_sanehosts_#{@timestamp}.log"
+    @live_log = File.join(ROOT, @live_log_rel)
+    @runtime_log = File.join(@run_dir, 'customer-ui-runtime-proof.log')
+    @execution_path = File.join(@run_dir, 'execution-evidence.json')
+    @fixture_home = File.join(@run_dir, 'fixture-home')
+    FileUtils.mkdir_p([@visual_dir, File.dirname(@live_log), @fixture_home])
+    @results = {}
+    @screenshots = []
+  end
+
+  def prepare_isolated_fixture!
+    @old_fixed_home = capture_launchctl_env('CFFIXED_USER_HOME')
+    @old_disable_keychain = capture_launchctl_env('SANEAPPS_DISABLE_KEYCHAIN')
+    @old_process_fixed_home = ENV['CFFIXED_USER_HOME']
+    ENV['CFFIXED_USER_HOME'] = @fixture_home
+    system!('launchctl', 'setenv', 'CFFIXED_USER_HOME', @fixture_home)
+    system!('launchctl', 'setenv', 'SANEAPPS_DISABLE_KEYCHAIN', '1')
+    system!('/usr/bin/defaults', 'write', APP_BUNDLE_ID, 'hideDockIcon', '-bool', 'false')
+    system!('/usr/bin/defaults', 'write', APP_BUNDLE_ID, 'hasAnsweredLaunchAtLoginDefaultPrompt', '-bool', 'true')
+    hosts = File.join(@run_dir, 'isolated-hosts')
+    File.write(hosts, "127.0.0.1 localhost\n0.0.0.0 #{FIXTURE_HOST}\n")
+    @fixture_rel = relative(File.join(@run_dir, 'fixture-state.json'))
+    write_json(File.join(ROOT, @fixture_rel), {
+      status: 'established',
+      actions: @actions.map { |action| action.fetch('id') },
+      isolation: 'CFFIXED_USER_HOME',
+      fixture_home: relative(@fixture_home),
+      hosts_fixture: relative(hosts),
+      hosts_sha256: Digest::SHA256.file(hosts).hexdigest,
+      real_hosts_mutated: false
+    })
+  end
+
+  def compile_ax_driver!
+    @ax_binary = File.join(@run_dir, 'customer_ui_ax_driver')
+    system!('xcrun', 'swiftc', AX_SOURCE, '-o', @ax_binary)
+  end
+
+  def start_live_log!
+    FileUtils.touch(@live_log)
+    @log_io = File.open(@live_log, 'a')
+    @log_pid = Process.spawn('/usr/bin/log', 'stream', '--style', 'compact', '--level', 'debug',
+                             '--predicate', 'process == "SaneHosts"', out: @log_io, err: @log_io)
+    @log_started_at = Time.now.utc
+  end
+
+  def launch_app!
+    system!('./scripts/SaneMaster.rb', 'test_mode', '--release', '--no-logs', chdir: ROOT)
+    deadline = Time.now + 30
+    sleep 0.2 until system('pgrep', '-x', 'SaneHosts', out: File::NULL) || Time.now >= deadline
+    raise 'SaneHosts did not launch' unless system('pgrep', '-x', 'SaneHosts', out: File::NULL)
+    raise 'Live log was not attached before launch' unless @log_started_at
+  end
+
+  def load_contract_identity!
+    out, err, status = Open3.capture3('./scripts/SaneMaster.rb', 'customer_ui_contract', '--json', '--no-exit', chdir: ROOT)
+    raise "Could not read customer contract identity: #{out}#{err}" unless status.success?
+
+    report = JSON.parse(out)
+    @manifest_sha = report.fetch('manifest_sha256')
+    @source_fingerprint = report.fetch('source_fingerprint')
+    @app_sha = git_sha(ROOT)
+    @saneui_sha = git_sha(File.expand_path('../../infra/SaneUI', ROOT))
+  end
+
+  def execute_action!(action)
+    id = action.fetch('id')
+    observations = @plans.fetch(id).map.with_index do |request, index|
+      execute_ax_request!(id, index, request)
+    end
+    raise "#{id}: action has no executed AX mutations" if observations.none? { |item| item.fetch('action') != 'read' }
+
+    screenshot_rel = "#{@run_rel}/visual/#{id}.png"
+    screenshot = File.join(ROOT, screenshot_rel)
+    system!(SCREENSHOT_WRAPPER, '--app', 'SaneHosts', '--mode', 'temp', '--path', screenshot)
+    raise "#{id}: canonical screenshot missing" unless File.size?(screenshot)
+    raise "#{id}: screenshot path was reused" if @screenshots.include?(screenshot_rel)
+
+    @screenshots << screenshot_rel
+    click_rel = "#{@run_rel}/#{id}-click.json"
+    state_rel = "#{@run_rel}/#{id}-state.json"
+    clicks = observations.map do |item|
+      {
+        control: item.fetch('control').fetch('label'),
+        action: item.fetch('action'),
+        observed_result: item.fetch('observedResult'),
+        performed_at: item.fetch('performedAt')
+      }
+    end
+    write_json(File.join(ROOT, click_rel), {
+      app: 'SaneHosts', host: Socket.gethostname, status: 'passed', execution_mode: 'executed',
+      action_id: id, screenshot: screenshot_rel, clicks: clicks
+    })
+    write_json(File.join(ROOT, state_rel), {
+      state: 'passed', actions: [id], screenshot_sha256: Digest::SHA256.file(screenshot).hexdigest,
+      readbacks: observations.map { |item| item.fetch('matchedReadbacks') },
+      safe_boundaries: SAFE_BOUNDARIES.fetch(id, [])
+    })
+    evidence = [
+      evidence('mini_click', "Executed #{clicks.length} AX mutations with bound readback", click_rel),
+      evidence('screenshot', 'Unique canonical Mini app screenshot', screenshot_rel),
+      evidence('fixture', 'Isolated fixed-home and hosts fixture', @fixture_rel),
+      evidence('log', 'Live unified log attached before launch', @live_log_rel),
+      evidence('state_receipt', 'Per-action AX readback and screenshot digest', state_rel)
+    ]
+    @results[id] = {
+      status: 'passed',
+      proof_level: action.fetch('required_proof_level'),
+      workflow: {
+        executed: true, runner: 'scripts/customer_ui_action_executor.rb',
+        outcome: observations.map { |item| item.fetch('observedResult') }.join(' | '),
+        steps_completed: action.fetch('steps'),
+        artifacts: evidence.map { |item| item.fetch(:path) }
+      },
+      functional_state: {
+        status: 'established',
+        detail: "Isolated fixture #{@fixture_rel}; no real /etc/hosts mutation"
+      },
+      inputs: action.fetch('user_inputs'),
+      output_assertions: action.fetch('expected_outputs'),
+      live_log: @live_log_rel,
+      safe_boundaries: SAFE_BOUNDARIES.fetch(id, []),
+      evidence: evidence
+    }
+  end
+
+  def execute_ax_request!(action_id, index, request)
+    request_path = File.join(@run_dir, format('%s-%02d-request.json', action_id, index + 1))
+    write_json(request_path, {
+      appName: request.fetch(:app_name), bundleID: request.fetch(:bundle_id),
+      action: request.fetch(:action), labels: request.fetch(:labels), roles: request.fetch(:roles),
+      value: request[:value], expected: request.fetch(:expected), timeoutSeconds: 12
+    })
+    out, err, status = Open3.capture3(@ax_binary, request_path)
+    raise "#{action_id}: AX driver failed: #{out}#{err}" unless status.success?
+
+    payload = JSON.parse(out)
+    raise "#{action_id}: AX driver did not return passed" unless payload['status'] == 'passed'
+    payload
+  end
+
+  def write_execution_evidence!
+    raise 'Live app log is empty' unless File.size?(@live_log)
+    payload = {
+      app: 'SaneHosts', host: Socket.gethostname, status: 'passed', execution_mode: 'executed',
+      generated_at: Time.now.utc.iso8601, manifest_sha256: @manifest_sha,
+      source_fingerprint: @source_fingerprint, app_git_sha: @app_sha, saneui_git_sha: @saneui_sha,
+      live_log: @live_log_rel, screenshots: @screenshots, action_results: @results
+    }
+    write_json(@execution_path, payload)
+  end
+
+  def ingest_evidence!
+    system!('./scripts/SaneMaster.rb', 'customer_ui_sweep', '--execution-evidence', relative(@execution_path),
+            '--json', chdir: ROOT)
+  end
+
+  def restore_gui_environment!
+    return unless @fixture_home
+
+    restore_launchctl_env('CFFIXED_USER_HOME', @old_fixed_home)
+    restore_launchctl_env('SANEAPPS_DISABLE_KEYCHAIN', @old_disable_keychain)
+    if @old_process_fixed_home
+      ENV['CFFIXED_USER_HOME'] = @old_process_fixed_home
+    else
+      ENV.delete('CFFIXED_USER_HOME')
+    end
+  end
+
+  def stop_live_log!
+    return unless @log_pid
+
+    Process.kill('TERM', @log_pid)
+    Process.wait(@log_pid)
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  ensure
+    @log_io&.close
+  end
+
+  def write_failure(error)
+    return unless @run_dir
+
+    write_json(File.join(@run_dir, 'execution-failed.json'), {
+      app: 'SaneHosts', status: 'failed', execution_mode: 'executed',
+      generated_at: Time.now.utc.iso8601, completed_action_ids: @results.keys,
+      error: "#{error.class}: #{error.message}"
+    })
+  end
+
+  def capture_launchctl_env(key)
+    out, status = Open3.capture2e('launchctl', 'getenv', key)
+    status.success? ? out.chomp : nil
+  end
+
+  def restore_launchctl_env(key, value)
+    value.to_s.empty? ? system('launchctl', 'unsetenv', key) : system('launchctl', 'setenv', key, value)
+  end
+
+  def git_sha(path)
+    out, status = Open3.capture2e('git', '-C', path, 'rev-parse', 'HEAD')
+    raise "Could not resolve Git HEAD: #{path}" unless status.success?
+    out.strip
+  end
+
+  def system!(*command, chdir: nil)
+    options = {}
+    options[:chdir] = chdir if chdir
+    success = system(*command, **options)
+    raise "Command failed: #{command.join(' ')}" unless success
+  end
+
+  def evidence(type, detail, path)
+    { type: type, detail: detail, path: path }
+  end
+
+  def write_json(path, payload)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, JSON.pretty_generate(payload) + "\n")
+  end
+
+  def relative(path)
+    path.delete_prefix("#{ROOT}/")
+  end
+end
+
+SaneHostsUIActionExecutor.new(ARGV).run if __FILE__ == $PROGRAM_NAME

--- a/scripts/customer_ui_action_executor.rb
+++ b/scripts/customer_ui_action_executor.rb
@@ -15,9 +15,13 @@ class SaneHostsUIActionExecutor
   MANIFEST = File.join(ROOT, 'Tests', 'CustomerUIActions.yml')
   AX_SOURCE = File.join(__dir__, 'customer_ui_ax_driver.swift')
   SCREENSHOT_WRAPPER = File.expand_path('../../infra/SaneProcess/scripts/mini/capture-mini-screenshot.sh', ROOT)
+  SCREENSHOT_HELPER_DIR = File.expand_path('~/.codex/skills/screenshot/scripts')
+  MINI_GUI_RUNNER = File.expand_path('../../infra/SaneProcess/scripts/mini/mini-gui-run.sh', ROOT)
   APP_BUNDLE_ID = 'com.mrsane.SaneHosts'
+  APP_EXECUTABLE = '/Applications/SaneHosts.app/Contents/MacOS/SaneHosts'
   FIXTURE_PROFILE = 'UI Proof Profile'
   FIXTURE_HOST = 'proof.invalid'
+  PROCESS_EXIT_TIMEOUT = 8
 
   SAFE_BOUNDARIES = {
     'menu-bar-profile-actions' => [
@@ -58,6 +62,7 @@ class SaneHostsUIActionExecutor
     @manifest = YAML.safe_load(File.read(MANIFEST), aliases: false)
     @actions = Array(@manifest.fetch('actions')).select { |action| action['release_required'] != false }
     @plans = build_plans
+    @owned_processes = []
     validate_plan!
   end
 
@@ -68,9 +73,11 @@ class SaneHostsUIActionExecutor
     require_clean_checkout!
     refuse_competing_gui!
     prepare_paths!
+    execution_error = nil
     begin
       prepare_isolated_fixture!
       compile_ax_driver!
+      validate_screenshot_route!
       start_live_log!
       launch_app!
       load_contract_identity!
@@ -79,12 +86,13 @@ class SaneHostsUIActionExecutor
       ingest_evidence!
       puts @execution_path
     rescue StandardError => e
-      write_failure(e)
-      raise
+      execution_error = e
     ensure
-      stop_live_log!
-      restore_gui_environment!
+      cleanup_error = cleanup_after_execution
+      write_failure(execution_error || cleanup_error, cleanup_error: cleanup_error) if execution_error || cleanup_error
     end
+    raise execution_error if execution_error
+    raise cleanup_error if cleanup_error
   end
 
   def plan_report
@@ -290,14 +298,38 @@ class SaneHostsUIActionExecutor
     @log_io = File.open(@live_log, 'a')
     @log_pid = Process.spawn('/usr/bin/log', 'stream', '--style', 'compact', '--level', 'debug',
                              '--predicate', 'process == "SaneHosts"', out: @log_io, err: @log_io)
+    register_owned_process!(:log, @log_pid)
     @log_started_at = Time.now.utc
   end
 
   def launch_app!
-    system!('./scripts/SaneMaster.rb', 'test_mode', '--release', '--no-logs', chdir: ROOT)
+    before = process_pids('SaneHosts')
+    raise "SaneHosts appeared before launch: #{before.join(', ')}" unless before.empty?
+
+    launch_error = nil
+    begin
+      system!('./scripts/SaneMaster.rb', 'test_mode', '--release', '--no-logs', chdir: ROOT)
+    rescue StandardError => e
+      launch_error = e
+    end
     deadline = Time.now + 30
-    sleep 0.2 until system('pgrep', '-x', 'SaneHosts', out: File::NULL) || Time.now >= deadline
-    raise 'SaneHosts did not launch' unless system('pgrep', '-x', 'SaneHosts', out: File::NULL)
+    launched = []
+    until Time.now >= deadline
+      launched = process_pids('SaneHosts') - before
+      break unless launched.empty? && launch_error.nil?
+      sleep 0.2
+    end
+    launched.each do |pid|
+      identity = process_identity(pid)
+      register_owned_process!(:app, pid, identity: identity) if identity&.include?(APP_EXECUTABLE)
+    end
+    raise launch_error if launch_error
+    raise 'SaneHosts did not launch' if launched.empty?
+    raise "Expected one launched SaneHosts process, found: #{launched.join(', ')}" unless launched.one?
+
+    @app_pid = launched.first
+    owned_app = @owned_processes.find { |owned| owned[:kind] == :app && owned[:pid] == @app_pid }
+    raise "Launched PID #{@app_pid} is not the canonical SaneHosts app" unless owned_app
     raise 'Live log was not attached before launch' unless @log_started_at
   end
 
@@ -321,7 +353,7 @@ class SaneHostsUIActionExecutor
 
     screenshot_rel = "#{@run_rel}/visual/#{id}.png"
     screenshot = File.join(ROOT, screenshot_rel)
-    system!(SCREENSHOT_WRAPPER, '--app', 'SaneHosts', '--mode', 'temp', '--path', screenshot)
+    system!(*screenshot_command(screenshot))
     raise "#{id}: canonical screenshot missing" unless File.size?(screenshot)
     raise "#{id}: screenshot path was reused" if @screenshots.include?(screenshot_rel)
 
@@ -416,24 +448,126 @@ class SaneHostsUIActionExecutor
     end
   end
 
-  def stop_live_log!
-    return unless @log_pid
-
-    Process.kill('TERM', @log_pid)
-    Process.wait(@log_pid)
-  rescue Errno::ESRCH, Errno::ECHILD
-    nil
-  ensure
-    @log_io&.close
+  def validate_screenshot_route!
+    dependencies = [
+      SCREENSHOT_WRAPPER,
+      MINI_GUI_RUNNER,
+      File.join(SCREENSHOT_HELPER_DIR, 'ensure_macos_permissions.sh'),
+      File.join(SCREENSHOT_HELPER_DIR, 'take_screenshot.py')
+    ]
+    missing = dependencies.reject { |path| File.file?(path) }
+    raise "Canonical Mini screenshot route is incomplete: #{missing.join(', ')}" unless missing.empty?
   end
 
-  def write_failure(error)
+  def screenshot_command(path)
+    [SCREENSHOT_WRAPPER, '--app', 'SaneHosts', '--mode', 'temp', '--path', path]
+  end
+
+  def cleanup_after_execution
+    errors = []
+    @owned_processes.reverse_each do |owned|
+      terminate_owned_process!(owned)
+    rescue StandardError => e
+      errors << "#{owned.fetch(:kind)} PID #{owned.fetch(:pid)}: #{e.message}"
+    end
+    begin
+      @log_io&.close
+    rescue StandardError => e
+      errors << "log handle: #{e.message}"
+    end
+    begin
+      restore_gui_environment!
+    rescue StandardError => e
+      errors << "environment: #{e.message}"
+    end
+    remaining = owned_processes_alive
+    errors << "owned processes remain: #{remaining.map { |item| "#{item[:kind]}=#{item[:pid]}" }.join(', ')}" unless remaining.empty?
+    write_cleanup_receipt(errors, remaining) if @run_dir
+    errors.empty? ? nil : StandardError.new("Executor cleanup failed: #{errors.join('; ')}")
+  end
+
+  def register_owned_process!(kind, pid, identity: nil)
+    resolved_identity = identity || process_identity(pid)
+    raise "Could not identify owned #{kind} PID #{pid}" if resolved_identity.to_s.empty?
+
+    @owned_processes << { kind: kind, pid: pid, identity: resolved_identity }
+  end
+
+  def terminate_owned_process!(owned)
+    pid = owned.fetch(:pid)
+    identity = owned.fetch(:identity)
+    return unless process_matches?(pid, identity)
+
+    signal_process('TERM', pid)
+    wait_for_owned_exit(pid, identity)
+    if process_matches?(pid, identity)
+      signal_process('KILL', pid)
+      wait_for_owned_exit(pid, identity)
+    end
+    raise "process did not exit after TERM/KILL" if process_matches?(pid, identity)
+  rescue Errno::ESRCH
+    nil
+  ensure
+    begin
+      wait_process(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+
+  def wait_for_owned_exit(pid, identity)
+    deadline = Time.now + PROCESS_EXIT_TIMEOUT
+    sleep 0.1 while process_matches?(pid, identity) && Time.now < deadline
+  end
+
+  def owned_processes_alive
+    @owned_processes.select { |owned| process_matches?(owned.fetch(:pid), owned.fetch(:identity)) }
+  end
+
+  def process_matches?(pid, identity)
+    process_identity(pid) == identity
+  end
+
+  def process_identity(pid)
+    out, status = Open3.capture2e('ps', '-p', pid.to_s, '-o', 'lstart=', '-o', 'command=')
+    status.success? && !out.strip.empty? ? out.strip : nil
+  end
+
+  def signal_process(signal, pid)
+    Process.kill(signal, pid)
+  end
+
+  def wait_process(pid)
+    Process.wait(pid, Process::WNOHANG)
+  end
+
+  def process_pids(name)
+    out, status = Open3.capture2e('pgrep', '-x', name)
+    return [] unless status.success?
+
+    out.lines.filter_map { |line| Integer(line.strip, exception: false) }
+  end
+
+  def write_cleanup_receipt(errors, remaining)
+    write_json(File.join(@run_dir, 'cleanup-receipt.json'), {
+      app: 'SaneHosts',
+      status: errors.empty? ? 'passed' : 'failed',
+      generated_at: Time.now.utc.iso8601,
+      owned_processes: @owned_processes,
+      remaining_owned_processes: remaining,
+      remaining_owned_process_count: remaining.length,
+      errors: errors
+    })
+  end
+
+  def write_failure(error, cleanup_error: nil)
     return unless @run_dir
 
     write_json(File.join(@run_dir, 'execution-failed.json'), {
       app: 'SaneHosts', status: 'failed', execution_mode: 'executed',
       generated_at: Time.now.utc.iso8601, completed_action_ids: @results.keys,
-      error: "#{error.class}: #{error.message}"
+      error: "#{error.class}: #{error.message}",
+      cleanup_error: cleanup_error && "#{cleanup_error.class}: #{cleanup_error.message}"
     })
   end
 

--- a/scripts/customer_ui_action_executor_test.rb
+++ b/scripts/customer_ui_action_executor_test.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'minitest/autorun'
 require 'open3'
 require 'rbconfig'
+require 'tmpdir'
 
 require_relative 'customer_ui_action_executor'
 
@@ -61,6 +62,142 @@ class SaneHostsUIActionExecutorTest < Minitest::Test
     assert_includes source, 'capture-mini-screenshot.sh'
     assert_includes source, "'--app', 'SaneHosts', '--mode', 'temp', '--path'"
     assert_includes source, "'customer_ui_sweep', '--execution-evidence'"
+  end
+
+  def test_screenshot_command_routes_locally_through_canonical_mini_wrapper
+    destination = '/tmp/sanehosts-proof.png'
+    command = @executor.send(:screenshot_command, destination)
+
+    assert_equal SaneHostsUIActionExecutor::SCREENSHOT_WRAPPER, command.first
+    assert_equal ['--app', 'SaneHosts', '--mode', 'temp', '--path', destination], command.drop(1)
+    refute_includes command, 'ssh'
+    refute command.any? { |argument| argument.include?('/usr/sbin/screencapture') }
+  end
+
+  def test_screenshot_route_preflight_requires_wrapper_runner_and_helpers
+    source = File.read(File.expand_path('customer_ui_action_executor.rb', __dir__))
+
+    assert_includes source, 'SCREENSHOT_WRAPPER'
+    assert_includes source, 'MINI_GUI_RUNNER'
+    assert_includes source, "File.join(SCREENSHOT_HELPER_DIR, 'ensure_macos_permissions.sh')"
+    assert_includes source, "File.join(SCREENSHOT_HELPER_DIR, 'take_screenshot.py')"
+    assert_includes source, 'validate_screenshot_route!'
+  end
+
+  def test_cleanup_terminates_only_exact_owned_app_and_log_processes
+    app_identity = "Mon Jul 30 12:00:00 2026 #{SaneHostsUIActionExecutor::APP_EXECUTABLE}"
+    log_identity = 'Mon Jul 30 11:59:59 2026 /usr/bin/log stream --predicate process == "SaneHosts"'
+    unrelated_identity = "Mon Jul 30 11:00:00 2026 #{SaneHostsUIActionExecutor::APP_EXECUTABLE}"
+    identities = { 101 => log_identity, 202 => app_identity, 303 => unrelated_identity }
+    signals = []
+
+    @executor.instance_variable_set(:@owned_processes, [
+                                      { kind: :log, pid: 101, identity: log_identity },
+                                      { kind: :app, pid: 202, identity: app_identity }
+                                    ])
+    @executor.define_singleton_method(:process_identity) { |pid| identities[pid] }
+    @executor.define_singleton_method(:signal_process) do |signal, pid|
+      signals << [signal, pid]
+      identities.delete(pid)
+    end
+    @executor.define_singleton_method(:wait_process) { |_pid| nil }
+    @executor.define_singleton_method(:restore_gui_environment!) {}
+
+    assert_nil @executor.send(:cleanup_after_execution)
+    assert_equal [['TERM', 202], ['TERM', 101]], signals
+    assert_equal unrelated_identity, identities.fetch(303)
+  end
+
+  def test_cleanup_runs_after_execution_failure_and_records_zero_owned_processes
+    app_identity = "Mon Jul 30 12:00:00 2026 #{SaneHostsUIActionExecutor::APP_EXECUTABLE}"
+    identities = { 404 => app_identity }
+    signals = []
+
+    Dir.mktmpdir do |run_dir|
+      executor = SaneHostsUIActionExecutor.new(['--execute'])
+      executor.instance_variable_set(:@actions, [{ 'id' => 'simulated-failure' }])
+      executor.define_singleton_method(:require_mini!) {}
+      executor.define_singleton_method(:require_clean_checkout!) {}
+      executor.define_singleton_method(:refuse_competing_gui!) {}
+      executor.define_singleton_method(:prepare_paths!) do
+        @run_dir = run_dir
+        @results = {}
+        @owned_processes = []
+      end
+      executor.define_singleton_method(:prepare_isolated_fixture!) {}
+      executor.define_singleton_method(:compile_ax_driver!) {}
+      executor.define_singleton_method(:validate_screenshot_route!) {}
+      executor.define_singleton_method(:start_live_log!) do
+        @owned_processes << { kind: :app, pid: 404, identity: app_identity }
+      end
+      executor.define_singleton_method(:launch_app!) {}
+      executor.define_singleton_method(:load_contract_identity!) {}
+      executor.define_singleton_method(:execute_action!) { |_action| raise 'simulated action failure' }
+      executor.define_singleton_method(:restore_gui_environment!) {}
+      executor.define_singleton_method(:process_identity) { |pid| identities[pid] }
+      executor.define_singleton_method(:signal_process) do |signal, pid|
+        signals << [signal, pid]
+        identities.delete(pid)
+      end
+      executor.define_singleton_method(:wait_process) { |_pid| nil }
+
+      error = assert_raises(RuntimeError) { executor.run }
+
+      assert_equal 'simulated action failure', error.message
+      assert_equal [['TERM', 404]], signals
+      cleanup = JSON.parse(File.read(File.join(run_dir, 'cleanup-receipt.json')))
+      assert_equal 'passed', cleanup.fetch('status')
+      assert_equal 0, cleanup.fetch('remaining_owned_process_count')
+      recorded_failure = JSON.parse(File.read(File.join(run_dir, 'execution-failed.json')))
+      assert_equal 'RuntimeError: simulated action failure', recorded_failure.fetch('error')
+      assert_nil recorded_failure.fetch('cleanup_error')
+    end
+  end
+
+  def test_cleanup_receipt_records_zero_owned_processes
+    app_identity = "Mon Jul 30 12:00:00 2026 #{SaneHostsUIActionExecutor::APP_EXECUTABLE}"
+    identities = { 404 => app_identity }
+    signals = []
+
+    Dir.mktmpdir do |run_dir|
+      @executor.instance_variable_set(:@run_dir, run_dir)
+      @executor.instance_variable_set(:@results, {})
+      @executor.instance_variable_set(:@owned_processes, [
+                                        { kind: :app, pid: 404, identity: app_identity }
+                                      ])
+      @executor.define_singleton_method(:process_identity) { |pid| identities[pid] }
+      @executor.define_singleton_method(:signal_process) do |signal, pid|
+        signals << [signal, pid]
+        identities.delete(pid)
+      end
+      @executor.define_singleton_method(:wait_process) { |_pid| nil }
+      @executor.define_singleton_method(:restore_gui_environment!) {}
+
+      cleanup_error = @executor.send(:cleanup_after_execution)
+
+      assert_nil cleanup_error
+      assert_equal [['TERM', 404]], signals
+      cleanup = JSON.parse(File.read(File.join(run_dir, 'cleanup-receipt.json')))
+      assert_equal 'passed', cleanup.fetch('status')
+      assert_equal 0, cleanup.fetch('remaining_owned_process_count')
+    end
+  end
+
+  def test_cleanup_does_not_signal_reused_pid_with_different_identity
+    original_identity = "Mon Jul 30 12:00:00 2026 #{SaneHostsUIActionExecutor::APP_EXECUTABLE}"
+    reused_identity = 'Mon Jul 30 12:01:00 2026 /Applications/Other.app/Contents/MacOS/Other'
+    signals = []
+
+    @executor.instance_variable_set(:@owned_processes, [
+                                      { kind: :app, pid: 505, identity: original_identity }
+                                    ])
+    @executor.define_singleton_method(:process_identity) { |_pid| reused_identity }
+    @executor.define_singleton_method(:signal_process) { |signal, pid| signals << [signal, pid] }
+    @executor.define_singleton_method(:wait_process) { |_pid| nil }
+    @executor.define_singleton_method(:restore_gui_environment!) {}
+
+    assert_nil @executor.send(:cleanup_after_execution)
+    assert_empty signals
   end
 
   def test_no_passed_execution_evidence_is_prefilled_in_plan

--- a/scripts/customer_ui_action_executor_test.rb
+++ b/scripts/customer_ui_action_executor_test.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+
+require_relative 'customer_ui_action_executor'
+
+class SaneHostsUIActionExecutorTest < Minitest::Test
+  def setup
+    @executor = SaneHostsUIActionExecutor.new(['--plan'])
+    @report = @executor.plan_report
+  end
+
+  def test_plan_matches_all_eleven_manifest_actions
+    assert_equal 11, @report.fetch(:action_count)
+    ids = @report.fetch(:actions).map { |action| action.fetch(:id) }
+    assert_equal @executor.plans.keys.sort, ids.sort
+  end
+
+  def test_every_action_has_ax_mutation_readback_and_unique_artifact_paths
+    screenshots = []
+    click_receipts = []
+    @report.fetch(:actions).each do |action|
+      refute_empty action.fetch(:controls)
+      refute_empty action.fetch(:ax_actions)
+      refute_empty action.fetch(:readbacks)
+      assert action.fetch(:ax_actions).any? { |name| name != 'read' }
+      assert action.fetch(:readbacks).all? { |groups| !groups.empty? }
+      screenshots << action.fetch(:screenshot)
+      click_receipts << action.fetch(:click_receipt)
+    end
+    assert_equal screenshots.length, screenshots.uniq.length
+    assert_equal click_receipts.length, click_receipts.uniq.length
+  end
+
+  def test_plan_mode_never_claims_execution
+    assert_equal 'not_executed', @report.fetch(:execution_mode)
+    output, error, status = Open3.capture3(
+      RbConfig.ruby,
+      File.expand_path('customer_ui_action_executor.rb', __dir__),
+      '--plan'
+    )
+    assert status.success?, error
+    parsed = JSON.parse(output)
+    assert_equal 'not_executed', parsed.fetch('execution_mode')
+    refute parsed.key?('action_results')
+  end
+
+  def test_safe_boundary_actions_declare_boundaries
+    bounded = @report.fetch(:actions).select { |action| !action.fetch(:safe_boundaries).empty? }
+    assert_operator bounded.length, :>=, 8
+  end
+
+  def test_command_construction_uses_canonical_launch_log_and_capture_paths
+    source = File.read(File.expand_path('customer_ui_action_executor.rb', __dir__))
+    assert_includes source, "'test_mode', '--release', '--no-logs'"
+    assert_includes source, "'/usr/bin/log', 'stream'"
+    assert_includes source, 'capture-mini-screenshot.sh'
+    assert_includes source, "'--app', 'SaneHosts', '--mode', 'temp', '--path'"
+    assert_includes source, "'customer_ui_sweep', '--execution-evidence'"
+  end
+
+  def test_no_passed_execution_evidence_is_prefilled_in_plan
+    @report.fetch(:actions).each do |action|
+      refute action.key?(:status)
+      refute action.key?(:steps_completed)
+    end
+  end
+end

--- a/scripts/customer_ui_ax_driver.swift
+++ b/scripts/customer_ui_ax_driver.swift
@@ -1,0 +1,261 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+private struct Request: Decodable {
+    let appName: String
+    let bundleID: String?
+    let action: String
+    let labels: [String]
+    let roles: [String]?
+    let value: String?
+    let expected: [[String]]
+    let timeoutSeconds: Double?
+}
+
+private struct ElementDescription: Codable {
+    let role: String
+    let label: String
+    let identifier: String
+}
+
+private struct Response: Codable {
+    let status: String
+    let control: ElementDescription?
+    let action: String
+    let observedResult: String
+    let matchedReadbacks: [String]
+    let performedAt: String
+    let error: String?
+}
+
+private enum DriverError: LocalizedError {
+    case invalidArguments
+    case accessibilityDenied
+    case appNotRunning(String)
+    case controlNotFound([String])
+    case actionFailed(String)
+    case readbackMissing([[String]])
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            "Usage: customer_ui_ax_driver REQUEST.json"
+        case .accessibilityDenied:
+            "Accessibility permission is required for the AX driver"
+        case let .appNotRunning(name):
+            "\(name) is not running"
+        case let .controlNotFound(labels):
+            "No visible AX control matched: \(labels.joined(separator: " | "))"
+        case let .actionFailed(action):
+            "AX action failed: \(action)"
+        case let .readbackMissing(groups):
+            "Post-action AX readback missing: \(groups.map { $0.joined(separator: " | ") }.joined(separator: " AND "))"
+        }
+    }
+}
+
+private func axString(_ element: AXUIElement, _ attribute: String) -> String {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return ""
+    }
+    if let string = value as? String {
+        return string.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    if let attributed = value as? NSAttributedString {
+        return attributed.string.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return ""
+}
+
+private func axBool(_ element: AXUIElement, _ attribute: String) -> Bool? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return nil
+    }
+    return value as? Bool
+}
+
+private func describe(_ element: AXUIElement) -> ElementDescription {
+    let role = axString(element, kAXRoleAttribute as String)
+    let values = [
+        axString(element, kAXTitleAttribute as String),
+        axString(element, kAXDescriptionAttribute as String),
+        axString(element, kAXValueAttribute as String),
+        axString(element, kAXHelpAttribute as String),
+        axString(element, "AXPlaceholderValue")
+    ].filter { !$0.isEmpty }
+    return ElementDescription(
+        role: role,
+        label: values.first ?? "",
+        identifier: axString(element, kAXIdentifierAttribute as String)
+    )
+}
+
+private func identityStrings(_ element: AXUIElement) -> [String] {
+    [
+        axString(element, kAXTitleAttribute as String),
+        axString(element, kAXDescriptionAttribute as String),
+        axString(element, kAXValueAttribute as String),
+        axString(element, kAXHelpAttribute as String),
+        axString(element, kAXIdentifierAttribute as String),
+        axString(element, "AXPlaceholderValue")
+    ].filter { !$0.isEmpty }
+}
+
+private func descendants(of root: AXUIElement, limit: Int = 8_000) -> [AXUIElement] {
+    var queue = [root]
+    var result: [AXUIElement] = []
+    while !queue.isEmpty, result.count < limit {
+        let element = queue.removeFirst()
+        if axBool(element, kAXHiddenAttribute as String) != true {
+            result.append(element)
+        }
+
+        var childrenValue: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenValue) == .success,
+           let children = childrenValue as? [AXUIElement] {
+            queue.append(contentsOf: children)
+        }
+    }
+    return result
+}
+
+private func matches(_ element: AXUIElement, labels: [String], roles: [String]?) -> Bool {
+    let role = axString(element, kAXRoleAttribute as String)
+    if let roles, !roles.isEmpty, !roles.contains(role) {
+        return false
+    }
+    let identities = identityStrings(element)
+    return labels.contains { wanted in
+        identities.contains { actual in
+            actual.caseInsensitiveCompare(wanted) == .orderedSame ||
+                actual.localizedCaseInsensitiveContains(wanted)
+        }
+    }
+}
+
+private func runningApplication(for request: Request) throws -> NSRunningApplication {
+    if let bundleID = request.bundleID,
+       let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first {
+        return app
+    }
+    if let app = NSWorkspace.shared.runningApplications.first(where: {
+        $0.localizedName?.caseInsensitiveCompare(request.appName) == .orderedSame
+    }) {
+        return app
+    }
+    throw DriverError.appNotRunning(request.appName)
+}
+
+private func waitForElements(
+    root: AXUIElement,
+    groups: [[String]],
+    timeout: Double
+) throws -> [String] {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+        let elements = descendants(of: root)
+        let matchedLabels = groups.compactMap { group -> String? in
+            for label in group where elements.contains(where: { matches($0, labels: [label], roles: nil) }) {
+                return label
+            }
+            return nil
+        }
+        if matchedLabels.count == groups.count {
+            return matchedLabels
+        }
+        Thread.sleep(forTimeInterval: 0.2)
+    } while Date() < deadline
+    throw DriverError.readbackMissing(groups)
+}
+
+private func perform(_ request: Request) throws -> Response {
+    guard AXIsProcessTrusted() else {
+        throw DriverError.accessibilityDenied
+    }
+    guard !request.expected.isEmpty else {
+        throw DriverError.readbackMissing([])
+    }
+
+    let app = try runningApplication(for: request)
+    let root = AXUIElementCreateApplication(app.processIdentifier)
+    let timeout = max(1, request.timeoutSeconds ?? 12)
+    var control: ElementDescription?
+
+    if request.action != "read" {
+        let deadline = Date().addingTimeInterval(timeout)
+        var target: AXUIElement?
+        repeat {
+            target = descendants(of: root).first {
+                matches($0, labels: request.labels, roles: request.roles)
+            }
+            if target == nil {
+                Thread.sleep(forTimeInterval: 0.2)
+            }
+        } while target == nil && Date() < deadline
+
+        guard let target else {
+            throw DriverError.controlNotFound(request.labels)
+        }
+        control = describe(target)
+
+        let result: AXError
+        switch request.action {
+        case "press":
+            result = AXUIElementPerformAction(target, kAXPressAction as CFString)
+        case "show_menu":
+            result = AXUIElementPerformAction(target, kAXShowMenuAction as CFString)
+        case "set_value":
+            guard let value = request.value else {
+                throw DriverError.actionFailed("set_value requires value")
+            }
+            result = AXUIElementSetAttributeValue(target, kAXValueAttribute as CFString, value as CFTypeRef)
+        default:
+            throw DriverError.actionFailed("unsupported action \(request.action)")
+        }
+        guard result == .success else {
+            throw DriverError.actionFailed("\(request.action) returned \(result.rawValue)")
+        }
+    }
+
+    let readbacks = try waitForElements(root: root, groups: request.expected, timeout: timeout)
+    return Response(
+        status: "passed",
+        control: control,
+        action: request.action,
+        observedResult: readbacks.joined(separator: " | "),
+        matchedReadbacks: readbacks,
+        performedAt: ISO8601DateFormatter().string(from: Date()),
+        error: nil
+    )
+}
+
+private func emit(_ response: Response) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try! encoder.encode(response)
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+do {
+    guard CommandLine.arguments.count == 2 else {
+        throw DriverError.invalidArguments
+    }
+    let data = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
+    let request = try JSONDecoder().decode(Request.self, from: data)
+    emit(try perform(request))
+} catch {
+    emit(Response(
+        status: "failed",
+        control: nil,
+        action: "none",
+        observedResult: "",
+        matchedReadbacks: [],
+        performedAt: ISO8601DateFormatter().string(from: Date()),
+        error: error.localizedDescription
+    ))
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- add a Mini-only external AX executor for all 11 customer action families
- require a live log before canonical launch, bound AX readback after every mutation, unique canonical screenshots, fixture/state receipts, and explicit safe boundaries
- emit the exact external evidence schema already enforced by the customer UI sweep
- fail if SaneClick still owns the Mini GUI or SaneHosts was launched before log attachment
- terminate only the exact app/logger PIDs owned by the executor and emit a cleanup receipt with zero remaining owned processes
- validate the canonical Mini screenshot route before launch

## Verification
- `ruby -c scripts/customer_ui_action_executor.rb`
- `xcrun swiftc -typecheck scripts/customer_ui_ax_driver.swift`
- `ruby scripts/customer_ui_action_executor_test.rb` (12 runs, 162 assertions)
- `ruby scripts/customer_ui_action_sweep_test.rb` (10 runs, 26 assertions)
- canonical Mini verify: 117 tests passed; receipt `c544712be28cd18a5eccdd903727eee0`
- cleanup receipt: `77e138a8c10451b3c86f73d459747662`

## Runtime status
Not run. This PR prepares the lane; it does not claim any customer action or screenshot has passed. First live execution must wait until the Mini GUI is free and use `ruby scripts/customer_ui_action_executor.rb --execute`.